### PR TITLE
feat: User-side API refactor

### DIFF
--- a/Sources/AppDebugMode/Providers/AppDebugModeProvider.swift
+++ b/Sources/AppDebugMode/Providers/AppDebugModeProvider.swift
@@ -10,23 +10,23 @@ import SwiftUI
 
 public final class AppDebugModeProvider {
     
-    // MARK: - Shared
-    
+    // MARK: - Singleton
+
     public static let shared = AppDebugModeProvider()
     
-    // MARK: - Init
-    
+    // MARK: - Initialization
+
     private init() {}
     
-    // MARK: - Properties
-    
-    var servers: [ApiServer] = []
-    var serversCollections: [ApiServerCollection] = []
-    var onServerChange: (() -> Void)?
-    var pushNotificationsProvider: PushNotificationsProvider?
-    
-    // MARK: - Methods
-    
+    // MARK: - Internal - Variables
+
+    internal var servers: [ApiServer] = []
+    internal var serversCollections: [ApiServerCollection] = []
+    internal var onServerChange: (() -> Void)?
+    internal var pushNotificationsProvider: PushNotificationsProvider?
+
+    // MARK: - Public - Variables
+
     @available(*, deprecated, renamed: "selectedUserProfile")
     public var selectedTestingUser: UserProfile? {
         UserProfilesProvider.shared.selectedUserProfile
@@ -39,8 +39,18 @@ public final class AppDebugModeProvider {
     @available(*, deprecated, renamed: "selectedUserProfilePublisher")
     public var selectedTestingUserPublisher = UserProfilesProvider.shared.selectedUserProfilePublisher
     public var selectedUserProfilePublisher = UserProfilesProvider.shared.selectedUserProfilePublisher
-    
-    public func setup(
+
+    public var shouldRedirectLogsToAppDebugMode: Bool {
+        StandardOutputService.shared.shouldRedirectLogsToAppDebugMode
+    }
+
+}
+
+// MARK: - Public - Helper functions
+
+public extension AppDebugModeProvider {
+
+    func setup(
         serversCollections: [ApiServerCollection],
         onServerChange: (() -> Void)? = nil,
         cacheManager: Any? = nil,
@@ -48,7 +58,7 @@ public final class AppDebugModeProvider {
     ) {
         self.serversCollections = serversCollections
         self.onServerChange = onServerChange
-        
+
         if let cacheManager {
             CacheProvider.shared.setup(cacheManager: cacheManager)
         }
@@ -56,22 +66,26 @@ public final class AppDebugModeProvider {
         if let firebaseMessaging {
             setupFirebaseMessaging(firebaseMessaging: firebaseMessaging)
         }
+
+        if StandardOutputService.shared.shouldRedirectLogsToAppDebugMode {
+            StandardOutputService.shared.redirectLogsToAppDebugMode()
+        }
     }
-    
-    public func getSelectedServer(for serverCollection: ApiServerCollection) -> ApiServer {
+
+    func getSelectedServer(for serverCollection: ApiServerCollection) -> ApiServer {
         serversCollections.first { $0 == serverCollection }!.selectedServer
     }
 
-    public func start() -> UIViewController {
+    func start() -> UIViewController {
         let view = AppDebugView(serversCollections: AppDebugModeProvider.shared.serversCollections)
         let hostingViewController = UIHostingController(rootView: view)
 
         return hostingViewController
     }
-    
+
 }
 
-// MARK: - Private
+// MARK: - Private - Helper functions
 
 private extension AppDebugModeProvider {
     

--- a/Sources/AppDebugMode/Screens/ConsoleLogsVIew/ConsoleLogsSettingsView.swift
+++ b/Sources/AppDebugMode/Screens/ConsoleLogsVIew/ConsoleLogsSettingsView.swift
@@ -15,7 +15,7 @@ struct ConsoleLogsSettingsView: View {
 
     init(standardOutputService: StandardOutputService, showSettings: Binding<Bool>) {
         self.standardOutputService = standardOutputService
-        self.redirectLogs = standardOutputService.shouldRedirectLogsToAppDebugView
+        self.redirectLogs = standardOutputService.shouldRedirectLogsToAppDebugMode
         _showSettings = showSettings
         UINavigationBar.appearance().titleTextAttributes = [.foregroundColor: UIColor.white]
     }
@@ -62,7 +62,7 @@ struct ConsoleLogsSettingsView: View {
                 }
 
                 ButtonFilled(text: "Save Log Settings") {
-                    standardOutputService.shouldRedirectLogsToAppDebugView = redirectLogs
+                    standardOutputService.shouldRedirectLogsToAppDebugMode = redirectLogs
                     exit(0)
                 }
                 .padding()

--- a/Sources/AppDebugMode/Utils/DebuggerService.swift
+++ b/Sources/AppDebugMode/Utils/DebuggerService.swift
@@ -1,0 +1,27 @@
+//
+//  DebuggerService.swift
+//  AppDebugMode-iOS
+//
+//  Created by Filip Šašala on 15/02/2024.
+//
+
+import Foundation
+
+public final class DebuggerService {
+
+    public static func debuggerConnected() -> Bool {
+        var processInfo = kinfo_proc()
+        var processInfoSize = MemoryLayout.stride(ofValue: processInfo)
+
+        var processIdentifiers: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+
+        let error = sysctl(&processIdentifiers, UInt32(processIdentifiers.count), &processInfo, &processInfoSize, nil, 0)
+        guard error == 0 else {
+            assertionFailure("sysctl failed")
+            return false
+        }
+
+        return (processInfo.kp_proc.p_flag & P_TRACED) != 0
+    }
+
+}

--- a/Sources/AppDebugMode/Utils/StandardOutputService.swift
+++ b/Sources/AppDebugMode/Utils/StandardOutputService.swift
@@ -8,70 +8,63 @@
 import SwiftUI
 import GoodPersistence
 
-public class StandardOutputService: ObservableObject {
+final class StandardOutputService: ObservableObject {
 
-    public static var shared = StandardOutputService()
+    // MARK: - Singleton
+
+    static var shared = StandardOutputService()
+
+    // MARK: - Log
 
     struct Log: Identifiable {
 
         var id: UInt64 {
-            uptime
+            absoluteSystemTime
         }
 
         let message: String
         let date = Date()
 
-        private let uptime: UInt64 = mach_absolute_time()
+        private let absoluteSystemTime: UInt64 = mach_absolute_time()
 
     }
+
+    // MARK: - Variables
 
     @Published var capturedOutput: [Log] = []
 
+    private var didRedirectLogs: Bool = false
     private var pipe = Pipe()
     private var count = 0
 
-    @UserDefaultValue("shouldRedirectLogsToAppDebugView", defaultValue: !DebuggerService.debuggerConnected())
-    public var shouldRedirectLogsToAppDebugView: Bool
+    @UserDefaultValue("shouldRedirectLogsToAppDebugMode", defaultValue: !DebuggerService.debuggerConnected())
+    var shouldRedirectLogsToAppDebugMode: Bool
 
-    public func redirectLogsToAppDebugView () {
-        setvbuf(stdout, nil, _IONBF, 0)
-        dup2(pipe.fileHandleForWriting.fileDescriptor,
-            STDOUT_FILENO)
-        pipe.fileHandleForReading.readabilityHandler = {
-         [weak self] handle in
-        let data = handle.availableData
-        let str = String(data: data, encoding: .utf8) ?? "<Non-utf8 data of size\(data.count)>\n"
-        DispatchQueue.main.async {
-            let log = Log(message: str)
-            guard !log.message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                return
+    // MARK: - Helper functions
+
+    func redirectLogsToAppDebugMode () {
+        guard !didRedirectLogs else { return } // redirect only once
+        didRedirectLogs = true
+
+        setvbuf(stdout, nil, _IONBF, 0) // set output as unbuffered
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            let str = String(data: data, encoding: .utf8) ?? "<\(data.count) bytes of non-UTF-8 data>\n"
+
+            DispatchQueue.main.async {
+                let log = Log(message: str)
+                guard !log.message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    return
+                }
+                self?.capturedOutput.append(log)
             }
-            self?.capturedOutput.append(log)
         }
-      }
     }
 
-    public func clearLogs() {
+    func clearLogs() {
         capturedOutput.removeAll()
-    }
-
-}
-
-public class DebuggerService {
-
-    static func debuggerConnected() -> Bool {
-        var processInfo = kinfo_proc()
-        var processInfoSize = MemoryLayout.stride(ofValue: processInfo)
-
-        var processIdentifiers: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
-
-        let error = sysctl(&processIdentifiers, UInt32(processIdentifiers.count), &processInfo, &processInfoSize, nil, 0)
-        guard error == 0 else {
-            assertionFailure("sysctl failed")
-            return false
-        }
-
-        return (processInfo.kp_proc.p_flag & P_TRACED) != 0
     }
 
 }


### PR DESCRIPTION
# Changelog:
- DebuggerService je presunuty do samostatneho suboru
- DebuggerService je public
---
- StandardOutputService je ako interna trieda
- Automaticka initializacia StandardOutputService spolu so zvyskom AppDebugModu (asi nemame use case, kedy by sme nechceli logy initializovat)
---
- Opravene referencie na kniznicu z `AppDebugView` na `AppDebugMode`
- Opraveny naming z `ConsoleLogVlew` na `ConsoleLogView`
- Codestyle 🐶 🔥 
- Rozdelenie SwiftUI obrazovky s logmi z jedneho body na samostatne funkcie kvoli udrzatelnosti kodu
